### PR TITLE
Exposed getMinutesRemainingInQueue() method in SpritzTexView

### DIFF
--- a/lib/src/main/java/com/andrewgiang/textspritzer/lib/SpritzerTextView.java
+++ b/lib/src/main/java/com/andrewgiang/textspritzer/lib/SpritzerTextView.java
@@ -256,4 +256,8 @@ public class SpritzerTextView extends TextView implements View.OnClickListener {
     public int getCurrentWordIndex() {
         return mSpritzer.mCurWordIdx;
     }
+
+    public int getMinutesRemainingInQueue() {
+        return mSpritzer.getMinutesRemainingInQueue();
+    }
 }


### PR DESCRIPTION
This method would help display relevant statistics about the text, I
think you initially meant to expose this (maybe).
